### PR TITLE
Document Typer CLI for CSV import command

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,37 @@
 
 Dividend Portfolio Tracker
 
+## Command-line interface
+
+The project uses [Typer](https://typer.tiangolo.com/) to build its CLI. Typer
+leverages Python type hints to parse arguments, generate `--help` output, and
+provide shell completion out of the box.
+
+### Example: CSV import
+
+A CSV import command can be defined with `@app.command()`:
+
+```python
+import typer
+from pathlib import Path
+
+app = typer.Typer()
+
+@app.command()
+def import_csv(file: Path):
+    """Import broker transactions from a CSV file."""
+    ...
+```
+
+Users run the command with:
+
+```bash
+python -m portfolio import-csv transactions.csv
+```
+
+Typer handles argument parsing and validation for `file`, automatically
+displaying helpful error messages and usage information.
+
 ## Implementation Plan
 
 1. **Project setup**


### PR DESCRIPTION
## Summary
- introduce Typer as the project's CLI framework
- show example `import_csv` command and usage

## Testing
- `pre-commit run --files README.md` *(fails: command not found)*
- `pip install pre-commit` *(fails: Could not find a version that satisfies the requirement pre-commit)*
- `pytest` (no tests found)


------
https://chatgpt.com/codex/tasks/task_e_6892fc1b412883259ea00a1a225192cb