### PR TITLE
Scaffold FastAPI project structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.py[cod]

--- a/README.md
+++ b/README.md
@@ -9,8 +9,7 @@ Dividend Portfolio Tracker
 | pandas | Data manipulation and analysis | Required |
 | yfinance | Retrieve market and dividend data | Required |
 | SQLAlchemy | ORM for SQLite database | Required |
-| FastAPI | Expose a REST API | Choose **FastAPI** or **Streamlit**, not both |
-| Streamlit | Build a simple web dashboard | Choose **Streamlit** or **FastAPI**, not both |
+| FastAPI | Expose a REST API | Chosen |
 | matplotlib / plotly | Visualize portfolio performance | Optional |
 | typer / click | Build CLI helpers | Optional |
 =======

--- a/portfolio/__init__.py
+++ b/portfolio/__init__.py
@@ -1,0 +1,3 @@
+"""Core package for the dividend portfolio tracker."""
+
+__all__ = ["models", "services", "importers", "api"]

--- a/portfolio/api/__init__.py
+++ b/portfolio/api/__init__.py
@@ -1,0 +1,11 @@
+"""FastAPI application exposing portfolio endpoints."""
+
+from fastapi import FastAPI
+
+app = FastAPI(title="Dividend Portfolio Tracker")
+
+
+@app.get("/health", tags=["health"])
+def health() -> dict[str, str]:
+    """Simple health check endpoint."""
+    return {"status": "ok"}

--- a/portfolio/importers/__init__.py
+++ b/portfolio/importers/__init__.py
@@ -1,0 +1,1 @@
+"""Importers for loading transaction data from external files."""

--- a/portfolio/models/__init__.py
+++ b/portfolio/models/__init__.py
@@ -1,0 +1,1 @@
+"""Database models for portfolios, holdings, and dividends."""

--- a/portfolio/services/__init__.py
+++ b/portfolio/services/__init__.py
@@ -1,0 +1,1 @@
+"""Service layer to interact with data sources and perform calculations."""

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,5 @@ pandas==2.1.1
 yfinance==0.2.28
 SQLAlchemy==2.0.20
 fastapi==0.103.2
-streamlit==1.27.2
 matplotlib==3.8.0
 plotly==5.17.0


### PR DESCRIPTION
## Summary
- choose FastAPI as the project interface and remove Streamlit dependency
- add initial package layout with models, services, importers and a FastAPI app
- include a health check endpoint and gitignore for compiled files

## Testing
- `pip install -r requirements.txt`
- `python - <<'PY'
import portfolio.api
print('app', type(portfolio.api.app))
PY`


------
https://chatgpt.com/codex/tasks/task_e_68930a4d372c8325844de660edfd04df